### PR TITLE
Update redux-saga version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "redux": "^3.3.1",
-    "redux-saga": "^0.8.0"
+    "redux-saga": "^0.10.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",


### PR DESCRIPTION
Current tutorial instructions aren't compatible with ^0.8.0 (a.k.a 0.8.x).