### PR TITLE
Add babel-node to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
+    "@babel/node": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.16.0",
     "babelify": "^10.0.0",


### PR DESCRIPTION
The `npm test` script requires `babel-node` to execute. 

As part of https://github.com/babel/babel/pull/6023, `babel-node` has become a standalone package. Therefore, it is required as a dev dependency within `package.json` in order to run the tests as specified in the redux-saga-beginner-tutorial.