### PR TITLE
adds babel node to the dev dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
+    "@babel/node": "^7.16.0",
     "@babel/preset-env": "^7.16.0",
     "@babel/preset-react": "^7.16.0",
     "babelify": "^10.0.0",


### PR DESCRIPTION
Currently, running the `test` script, throws `sh: babel-node: command not found`
Adding babel node fixes this issue.