### PR TITLE
Update main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@ import "@babel/polyfill"
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { createStore, applyMiddleware } from 'redux'
+import { legacy_createStore as createStore, applyMiddleware } from 'redux'
 
 import Counter from './Counter'
 import reducer from './reducers'


### PR DESCRIPTION
As of Redux 4.2. 0, which was released April 2022, Redux has deprecated its createStore API.
Instead one can import legacy_createStore as createStore for the application to run in harmony without any additional warnings or polyfills